### PR TITLE
Harden The NiFi Toolkit Download Process

### DIFF
--- a/reporting/docker-compose.yml
+++ b/reporting/docker-compose.yml
@@ -42,12 +42,7 @@ services:
       - ./nifi/libs:/tmp/nifi-libs
       - ./nifi/scripts:/tmp/nifi-scripts
     entrypoint: >
-      bash -c "chown -R nifi:nifi /tmp/nifi-libs/*
-      && chmod -R 0640 /tmp/nifi-libs/*
-      && cp /tmp/nifi-libs/* lib/
-      && /tmp/nifi-scripts/download-toolkit.sh ${OL_NIFI_VERSION}
-      && /tmp/nifi-scripts/preload.sh init ${OL_NIFI_VERSION}&
-        ../scripts/start.sh"
+      bash -c "/tmp/nifi-scripts/start.sh ${OL_NIFI_VERSION}"
     logging:
       driver: syslog
       options:

--- a/reporting/nifi/scripts/download-toolkit.sh
+++ b/reporting/nifi/scripts/download-toolkit.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
+export NIFI_TOOLKIT_DOWNLOAD_MAX_RETRIES=3
 
 downloadNifiToolkit() {
   local nifiVersion=$1
+  local retryCount=$2
   local downloadDir=/tmp/nifi-scripts/cache
   local archivePath=${downloadDir}/nifi-toolkit-${nifiVersion}.tar.gz
+
+  if [ "$retryCount" -gt "$NIFI_TOOLKIT_DOWNLOAD_MAX_RETRIES" ]; then
+    echo "Failed to download NiFi Toolkit $NIFI_TOOLKIT_DOWNLOAD_MAX_RETRIES times. Exiting!"
+    return 2
+  fi
+
   mkdir -p ${downloadDir}
   if ! [[ -e $archivePath ]]; then
-    echo "Downloading the NiFi Toolkit archive"
+    echo "Downloading the NiFi Toolkit archive (${retryCount})."
     curl -f -o $archivePath http://archive.apache.org/dist/nifi/${nifiVersion}/nifi-toolkit-${nifiVersion}-bin.tar.gz
     if [ $? -ne 0 ]; then
       return 1
     fi
   fi
 
-  extractNifiToolkit "$nifiVersion" "$archivePath"
+  extractNifiToolkit "$nifiVersion" "$archivePath" "$retryCount"
   
   return $?
 }
@@ -21,13 +29,23 @@ downloadNifiToolkit() {
 extractNifiToolkit() {
   local nifiVersion=$1
   local archivePath=$2
+  local retryCount=$3
   local destDir=/tmp
-  echo "Extracting the NiFi Toolkit archive to $destDir/nifi-toolkit-$nifiVersion"
+  echo "Extracting the NiFi Toolkit archive to $destDir/nifi-toolkit-$nifiVersion."
   rm -rf $destDir/nifi-toolkit-$nifiVersion
   tar -xf $archivePath -C $destDir
 
-  return $?
+  if [ $? -ne 0 ]; then
+    rm $archivePath
+    echo "Could not extract NiFi Toolkit. Restarting the download."
+    retryCount=$((retryCount + 1))
+    downloadNifiToolkit "$nifiVersion" "$retryCount"
+
+    return $?
+  fi
+
+  return 0
 }
 
-downloadNifiToolkit "$1"
+downloadNifiToolkit "$1" 0
 exit $?

--- a/reporting/nifi/scripts/preload.sh
+++ b/reporting/nifi/scripts/preload.sh
@@ -6,7 +6,7 @@ export REG_CLIENTS_DIR="$WORKING_DIR/preload/registries"
 export IMPORTED_REG_CLIENTS_DIR="/tmp/nifi-preload/registries"
 export PROC_GROUPS_DIR="$WORKING_DIR/preload/process-groups"
 export IMPORTED_PROC_GROUPS_DIR="/tmp/nifi-preload/process-groups"
-export NIFI_UP_RETRY_COUNT=50
+export NIFI_UP_RETRY_COUNT=240
 
 main() {
   if waitNifiAvailable ${NIFI_UP_RETRY_COUNT}; then
@@ -25,6 +25,7 @@ main() {
 }
 
 waitNifiAvailable() {
+  echo "Waiting for NiFi to be available"
   local maxTries=$1
   local retryCount=1
 
@@ -45,6 +46,7 @@ initialize() {
 }
 
 createRegClients() {
+  echo "Importing the Registry Clients"
   local nifiVersion=$1
   local cliPath=$(getCliPath "$nifiVersion")
   local returnCode=0
@@ -68,6 +70,7 @@ createRegClients() {
 }
 
 importProcessGroups() {
+  echo "Importing the Process Groups"
   local nifiVersion=$1
   local cliPath=$(getCliPath "$nifiVersion")
   local returnCode=0
@@ -120,5 +123,5 @@ getCliPath() {
   echo "/tmp/nifi-toolkit-${nifiVersion}/bin/cli.sh"
 }
 
-main "$@"
+main "$@" &
 exit $?

--- a/reporting/nifi/scripts/start.sh
+++ b/reporting/nifi/scripts/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+chown -R nifi:nifi /tmp/nifi-libs/* &&
+chmod -R 0640 /tmp/nifi-libs/* &&
+cp /tmp/nifi-libs/* lib/ &&
+/tmp/nifi-scripts/download-toolkit.sh $1 &&
+/tmp/nifi-scripts/preload.sh init $1 &&
+cd /opt/nifi/nifi-$1 &&
+../scripts/start.sh


### PR DESCRIPTION
NiFi Toolkit might fail to fully download especially when the internet
connection is intermittent. Add functionaility for retrying the download
process if this happens.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>