### PR TITLE
Use Different NGINX Server Blocks for HTTP and HTTPS

### DIFF
--- a/reporting/config/services/nginx/consul-template/openlmis.conf
+++ b/reporting/config/services/nginx/consul-template/openlmis.conf
@@ -27,16 +27,33 @@ server {
   server_name {{ $location }};
   listen 80;
 
+{{ if $locationData.enable_ssl }}
+  return 301 https://$server_name$request_uri;
+{{ else }}
   location / {
     proxy_pass http://{{ $locationData.upstream }};
+    proxy_set_header X-ProxyScheme http;
+    proxy_set_header X-ProxyHost {{ $location }};
+    proxy_set_header X-ProxyPort 80;
+    proxy_set_header X-ProxyContextPath /;
+
   }
+{{ end }}
+}
 
 {{ if $locationData.enable_ssl }}
-  if ($scheme = http) {
-        return 301 https://$server_name$request_uri;
+server {
+  server_name {{ $location }};
+
+  location / {
+    proxy_pass http://{{ $locationData.upstream }};
+    proxy_set_header X-ProxyScheme https;
+    proxy_set_header X-ProxyHost {{ $location }};
+    proxy_set_header X-ProxyPort 443;
+    proxy_set_header X-ProxyContextPath /;
   }
 
-  listen 443 ssl;
+  listen 443;
   ssl on;
   ssl_certificate           {{ $locationData.ssl_cert }};
   ssl_certificate_key       {{ $locationData.ssl_key }};
@@ -51,7 +68,6 @@ server {
   add_header                Strict-Transport-Security 'max-age=15768000';
   ssl_stapling              on;
   ssl_session_cache         builtin:1000 shared:SSL:10m;
-{{ end }}
 }
-
+{{ end }}
 {{ end }}

--- a/reporting/docker-compose.yml
+++ b/reporting/docker-compose.yml
@@ -55,8 +55,8 @@ services:
     volumes:
       - config-volume:/config
     entrypoint: >
-      sh -c "cp -r /config/nginx/consul-template/* /etc/consul-template/
-      && openssl dhparam -dsaparam -out /etc/ssl/certs/dhparam.pem 4096
+      sh -c "openssl dhparam -dsaparam -out /etc/ssl/certs/dhparam.pem 4096
+      && cp -r /config/nginx/consul-template/* /etc/consul-template/
       && /home/run.sh"
     logging:
       driver: syslog


### PR DESCRIPTION
In the reporting stack, use different NGINX server blocks for HTTP and
HTTPS traffic. Do this to prevent from getting 400 errors from NGINX.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>