### PR TITLE
OLMIS-5692: Add the Host & X-Forwarded-Port to Reporting NGINX

### DIFF
--- a/reporting/config/services/nginx/consul-template/openlmis.conf
+++ b/reporting/config/services/nginx/consul-template/openlmis.conf
@@ -34,6 +34,9 @@ server {
     proxy_pass http://{{ $locationData.upstream }};
     proxy_set_header X-ProxyScheme http;
     proxy_set_header X-ProxyHost {{ $location }};
+    proxy_set_header Host {{ $location }};
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-ProxyPort 80;
     proxy_set_header X-ProxyContextPath /;
 
@@ -49,6 +52,9 @@ server {
     proxy_pass http://{{ $locationData.upstream }};
     proxy_set_header X-ProxyScheme https;
     proxy_set_header X-ProxyHost {{ $location }};
+    proxy_set_header Host {{ $location }};
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-ProxyPort 443;
     proxy_set_header X-ProxyContextPath /;
   }


### PR DESCRIPTION
Adds the Host and X-Forwarded-Port headers in the NGINX
template for the reporting stack.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>