### PR TITLE
Access superset data from external source

### DIFF
--- a/reporting/config/services/superset/security.py
+++ b/reporting/config/services/superset/security.py
@@ -47,6 +47,8 @@ class AuthOAuthView(AuthOAuthView):
         logging.debug("Authorized init")
         resp = self.appbuilder.sm.oauth_remotes[provider].authorized_response()
         redirect_url = request.args.get('redirect_url')
+        if 'custom_api_token' in request.headers:
+            resp = {'access_token': request.headers['custom_api_token']}
         if resp is None:
             flash(u'You denied the request to sign in.', 'warning')
             return redirect('login')


### PR DESCRIPTION
Superset provides an endpoint for slice data in superset/views/core.py

```
 @log_this
    @api
    @has_access_api
    @expose('/slice_json/<slice_id>')
    def slice_json(self, slice_id):
        form_data, slc = self.get_form_data(slice_id, use_slice_data=True)
        datasource_type = slc.datasource.type
        datasource_id = slc.datasource.id
        return self.generate_json(datasource_type=datasource_type,
                                  datasource_id=datasource_id,
                                  form_data=form_data)
```
The json returned contains a lot of information, including the data in the slice, the query used to create it, the filters available in the slice and the datasource.

This endpoint however requires cookie authentication. So to get data from it, you first need to log in

You can either make the request with a username and password:

`curl --cookie-jar cookies.txt -s -L https://superset.ona.io/login/ -u <username>:<password>`

or you can use the user's access token,

`curl --cookie-jar cookies.txt -s -L https://superset.ona.io/oauth-authorized/openlmis -H 'custom_api_token: <access-token>'`

and then to get slice data
`curl -b cookies.txt https://superset.ona.io/superset/slice_json/<slide-id>`