### PR TITLE
Retrieve sensitive values from .env file

### DIFF
--- a/reporting/.env
+++ b/reporting/.env
@@ -46,17 +46,17 @@ NIFI_SSL_KEY=nifi.local.key
 NIFI_SSL_CERT_CHAIN=nifi.local.crt
 # Whether to enable accessing the NiFi domain securely
 NIFI_ENABLE_SSL=false
+# Nifi Passwords 
+DB_PASSWORD=p@ssw0rd
+INVOKEHTTP_PASSWORD=changeme
 
 ### Scalyr Service ###
-
 # Path to the Docker socket file on the host machine
 # Instructions on how to get the path can be found
 # here https://www.scalyr.com/help/install-agent-docker
 SCALYR_DOCKER_SOCK=/run/docker.sock
 
-
 ### Rsyslog ###
-
 # The UDP port to send logs to the syslog container
 SYSLOG_UDP_PORT=51400
 
@@ -64,3 +64,5 @@ SYSLOG_UDP_PORT=51400
 # For services (like NiFi) that need to be authenticated but currently don't, by themselves, authenticate users 
 NGINX_BASIC_AUTH_USER=admin
 NGINX_BASIC_AUTH_PW=changeme
+
+

--- a/reporting/config/services/nifi/scripts/start.sh
+++ b/reporting/config/services/nifi/scripts/start.sh
@@ -2,6 +2,6 @@
 
 cp /config/nifi/libs/* lib/ &&
 /config/nifi/scripts/download-toolkit.sh $1 &&
-/config/nifi/scripts/preload.sh init $1 &&
+/config/nifi/scripts/preload.sh init $1 $2 $3 &&
 cd /opt/nifi/nifi-$1 &&
 ../scripts/start.sh

--- a/reporting/docker-compose.yml
+++ b/reporting/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - config-volume:/config
       - ./nifi-cache:/tmp/nifi-docker-cache
     entrypoint: >
-      bash -c "/config/nifi/scripts/start.sh ${OL_NIFI_VERSION}"
+      bash -c "/config/nifi/scripts/start.sh ${OL_NIFI_VERSION} ${DB_PASSWORD} ${INVOKEHTTP_PASSWORD}"
     logging:
       driver: syslog
       options:


### PR DESCRIPTION
The nifi `controller services` and `InvokeHTTP` processor passwords are now retrieved from the .env file.