### PR TITLE
Change base image of openlmis/awscli to alpine

### DIFF
--- a/utils/awscli/Dockerfile
+++ b/utils/awscli/Dockerfile
@@ -1,4 +1,4 @@
-FROM openlmis/dev:3
+FROM alpine:3.8
 
 RUN apk -v --update add \
     python \

--- a/utils/awscli/README.md
+++ b/utils/awscli/README.md
@@ -1,8 +1,6 @@
 # AWS CLI utility docker image
 
-Wraps the AWS CLI utility - like many other images do.  This has the advantage of being based
-off of the openlmis/dev image (so it's overall larger, however it shares layers with openlmis/dev
-reducing the actual layers downloaded - hopefully).  When/if AWS produces an official CLI image,
+Wraps the AWS CLI utility - like many other images do. When/if AWS produces an official CLI image,
 this should likely be replaced.
 
 ## Usage


### PR DESCRIPTION
Since openlmis/dev is based on an image based on alpine, we can reduce the image size by using alpine directly.

By using the same version of alpine as openlmis/dev base java  image, we can keep the benefit of having to download less layers when used  in the same environment as openlmis/dev.
