### PR TITLE
Add tip to docker logging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,12 +208,11 @@ all of these messages to the file `/var/log/messages` of the named volume `syslo
 To read this file, you may mount this filesystem via:
 
 ```shell
-$ docker run -it --rm -v openlmisrefdistro_syslog:/var/log 
-
-
-:3 bash
+docker run -it --rm -v openlmis-ref-distro_syslog:/var/log openlmis/dev:3 bash
 > tail /var/log/messages
 ```
+
+Different versions of docker and different deployment configurations can result in different names of the syslog volume. If `openlmis-ref-distro_nginx-log` doesn't work, run `docker volume ls` to see all volume names.
 
 #### Log format for Services
 
@@ -233,9 +232,11 @@ The `nginx` container runs the nginx and consul-template processes.  These two l
 e.g to see Nginx's access log:
 
 ```shell
-$ docker run -it --rm -v openlmisrefdistro_nginx-log:/var/log/nginx/log openlmis/dev:3 bash
+$ docker run -it --rm -v openlmis-ref-distro_nginx-log:/var/log/nginx/log openlmis/dev:3 bash
 > tail /var/log/nginx/log/access.log
 ```
+
+Different versions of docker and different deployment configurations can result in different names of the syslog volume. If `openlmis-ref-distro_nginx-log` doesn't work, run `docker volume ls` to see all volume names.
 
 With Nginx it's also possible to use Docker's logging so that both logs are accessible via `docker logs <nginx>`.  
 This is owed to the configuration of the official Nginx image.  To use this configuration, change the environment

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ docker run -it --rm -v openlmis-ref-distro_syslog:/var/log openlmis/dev:3 bash
 > tail /var/log/messages
 ```
 
-Different versions of docker and different deployment configurations can result in different names of the syslog volume. If `openlmis-ref-distro_nginx-log` doesn't work, run `docker volume ls` to see all volume names.
+Different versions of docker and different deployment configurations can result in different names of the syslog volume. If `openlmis-ref-distro_syslog` doesn't work, run `docker volume ls` to see all volume names.
 
 #### Log format for Services
 


### PR DESCRIPTION
The given `docker run ...` commands didn't work for me, so I just opened a shell in the container I wanted.

Not sure if we want to debug the commands that are currently in the docs and/or replace them entirely. This command seems to have syntax issues:
```shell
$ docker run -it --rm -v openlmisrefdistro_syslog:/var/log 

:3 bash
```
But even this one doesn't give me access to `/var/log/messages`:
```shell
docker run -it --rm -v openlmisrefdistro_syslog:/var/log openlmis/dev:3 bash
```
